### PR TITLE
Add DTPSR paper and code links to CVPR2026.md

### DIFF
--- a/CVPR2026.md
+++ b/CVPR2026.md
@@ -70,6 +70,10 @@ CVPR完整论文库：
 - Paper: 
 - Code: https://github.com/yuhangwang-ai/CDA-VSR
 
+### Disentangled Textual Priors for Diffusion-based Image Super-Resolution
+- Paper: https://arxiv.org/abs/2603.07430
+- Code: https://github.com/JL6666JL/DTPSR
+
 ### DUO-VSR: Dual-Stream Distillation for One-Step Video Super-Resolution
 - Paper: 
 - Code: https://github.com/cszy98/DUO-VSR


### PR DESCRIPTION
Added a new section for 'Disentangled Textual Priors for Diffusion-based Image Super-Resolution' with links to the paper and code.